### PR TITLE
Fixed Typo

### DIFF
--- a/topics/regulation.json
+++ b/topics/regulation.json
@@ -10,7 +10,7 @@
         },
         "items": [
             {
-                "title": "Switserland",
+                "title": "Switzerland",
                 "axis": {
                     "x": 0.16544389524799358,
                     "y": 0.8052362433806518


### PR DESCRIPTION
Switzerland was not written properly. Furthermore, this chart is not really representing the reality, Japan and South Korea for example do not have an unfavorable stance towards crypto at all, in fact they are both pushing adoption harder than most other countries (especially Japan). Of course regulation is increasing, but they are not going to ban crypto per se, they are trying to prevent fraud and illegal activities by unregulated exchanges, therefore the "bans" are not towards crypto but towards bad exchange practices and selling of unregistered securities (what many ERC20 tokens are).

Before I update the positioning of the countries in the chart I would need to know what criteria are determining the position of a country in the chart?

But great work, keep it up!