### PR TITLE
Removed Ripple

### DIFF
--- a/topics/token-development.json
+++ b/topics/token-development.json
@@ -48,15 +48,6 @@
                 "id": "bat"
             },
             {
-                "title": "Ripple",
-                "description": "Ripple (XRP)\n\nhttps://ripple.com/",
-                "axis": {
-                    "x": 0.5310344848632812,
-                    "y": 0.7275862121582031
-                },
-                "id": "xrp"
-            },
-            {
                 "title": "Cardano",
                 "description": "Cardano (ADA)\n\nhttps://www.cardanohub.org",
                 "axis": {


### PR DESCRIPTION
Ripple did neither do an ICO (http://ripple-guide.com/ripple-project-older-bitcoin-ripple-ico) nor is Ripple a token like the other projects in this chart, doesn't belong here.